### PR TITLE
replace deprecated Buffer constructor usage

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -36,7 +36,7 @@ module.exports = function(opt, cb) {
     //we need to convert it into a regular Buffer object
     if (isArrayBuffer(body)) {
       var array = new Uint8Array(body)
-      body = new Buffer(array, 'binary')
+      body = Buffer.from(array, 'binary')
     }
 
     //now check the string/Buffer response
@@ -45,7 +45,7 @@ module.exports = function(opt, cb) {
       binary = true
       //if we have a string, turn it into a Buffer
       if (typeof body === 'string') 
-        body = new Buffer(body, 'binary')
+        body = Buffer.from(body, 'binary')
     } 
 
     //we are not parsing a binary format, just ASCII/XML/etc

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function parseFont(file, data, cb) {
   var result, binary
 
   if (isBinary(data)) {
-    if (typeof data === 'string') data = new Buffer(data, 'binary')
+    if (typeof data === 'string') data = Buffer.from(data, 'binary')
     binary = true
   } else data = data.toString().trim()
 

--- a/lib/is-binary.js
+++ b/lib/is-binary.js
@@ -1,5 +1,5 @@
 var equal = require('buffer-equal')
-var HEADER = new Buffer([66, 77, 70, 3])
+var HEADER = Buffer.from([66, 77, 70, 3])
 
 module.exports = function(buf) {
   if (typeof buf === 'string')


### PR DESCRIPTION
https://github.com/Jam3/load-bmfont/pull/7

See https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/

Closes #6